### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ See this example setting a couple of Web radios to my two chromecast players.
 
 *Excerpt of ui-lovelace.yaml*
 ```
-resources:
-  - url: /local/jukebox.js
-    type: module
+resources:  
+  - type: module
+    url: /local/jukebox.js?v=1
+    
 views:
 - name: Example
   cards:


### PR DESCRIPTION
I had to add "v=1" to the url-line, otherwise HA didn't find the module. Is this a demand in newer versions of Home Assistant maybe?  

- type: module
    url: /local/jukebox.js?v=1