### PR TITLE
Added radio name and logo to media_player instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ I recommend using [HACS](https://hacs.xyz/) to install and update this integrati
 ### Configuration
 Find stream URLs, e.g. on [Radio-Browser.info](http://www.radio-browser.info/gui/#/)
 See this example setting a couple of Web radios to my two chromecast players.
+A logo can be added (optional) and will be displayed on target media player lovelace card (as album cover).
 
 #### Using lovlace in yaml mode
 
@@ -50,6 +51,9 @@ views:
         name: Concertzender Jazz
       - url: http://fs-insidejazz.fast-serv.com:8282/;stream.nsv
         name: Inside Jazz
+      - url: http://icecast.radiofrance.fr/franceinfo-midfi.mp3
+        name: France Info
+        logo: https://upload.wikimedia.org/wikipedia/fr/thumb/1/18/France_Info_-_2008.svg/768px-France_Info_-_2008.svg.png
       - url: http://stream.srg-ssr.ch/m/rsj/mp3_128
         name: Radio Swiss Jazz
       - url: http://stream.beachlatinoradio.com:8030/;?d=
@@ -78,6 +82,9 @@ links:
     name: Concertzender Jazz
   - url: http://fs-insidejazz.fast-serv.com:8282/;stream.nsv
     name: Inside Jazz
+  - url: http://icecast.radiofrance.fr/franceinfo-midfi.mp3
+    name: France Info
+    logo: https://upload.wikimedia.org/wikipedia/fr/thumb/1/18/France_Info_-_2008.svg/768px-France_Info_-_2008.svg.png
   - url: http://stream.srg-ssr.ch/m/rsj/mp3_128
     name: Radio Swiss Jazz
   - url: http://stream.beachlatinoradio.com:8030/;?d=

--- a/jukebox-card.js
+++ b/jukebox-card.js
@@ -49,7 +49,7 @@ class JukeboxCard extends HTMLElement {
         stationList.classList.add('station-list');
 
         this.config.links.forEach(linkCfg => {
-            const stationButton = this.buildStationSwitch(linkCfg.name, linkCfg.url)
+            const stationButton = this.buildStationSwitch(linkCfg.name, linkCfg.url, linkCfg.logo )
             this._stationButtons.push(stationButton);
             stationList.appendChild(stationButton);
         });
@@ -170,9 +170,11 @@ class JukeboxCard extends HTMLElement {
         })
     }
 
-    buildStationSwitch(name, url) {
+    buildStationSwitch(name, url, logo) {
         const btn = document.createElement('mwc-button');
         btn.stationUrl = url;
+		btn.stationName = name;
+		btn.stationLogo = logo;
         btn.className = 'juke-toggle';
         btn.innerText = name;
         btn.addEventListener('click', this.onStationSelect.bind(this));
@@ -183,7 +185,17 @@ class JukeboxCard extends HTMLElement {
         this.hass.callService('media_player', 'play_media', {
             entity_id: this._selectedSpeaker,
             media_content_id: e.currentTarget.stationUrl,
-            media_content_type: 'audio/mp4'
+            media_content_type: 'audio/mp4',
+			extra: {
+				metadata: {
+				  metadataType: 3,
+				  title: e.currentTarget.stationName,
+				  artist: "Live Radio",
+				  images: [ 
+					{ url: e.currentTarget.stationLogo }
+				  ]
+				}
+			}
         });
     }
 


### PR DESCRIPTION
Adds info to the playing media_player instance 
- radio name (as named in lovelace card radio list)
- radio logo (as album cover) if a url is provided in lovelace card radio list

It works with 'google cast' media_player type. 
I actually don't know how it would react on other type of players (such as spotify) 